### PR TITLE
Test/memory storage

### DIFF
--- a/src/storage/abstract.ts
+++ b/src/storage/abstract.ts
@@ -22,11 +22,11 @@ export interface GenericStorageOptions {
 /**
  * Storage initializer type
  */
-export type StorageInitializer = () => Promise<Storage>;
+export type StorageInitializer<T extends Storage = Storage> = () => Promise<T>;
 
 /**
  * Storage initializer callback function type
  */
-export type StorageInitializerFunction = (
+export type StorageInitializerFunction<T extends Storage = Storage> = (
   options?: GenericStorageOptions,
-) => StorageInitializer;
+) => StorageInitializer<T>;

--- a/src/storage/local.ts
+++ b/src/storage/local.ts
@@ -222,7 +222,7 @@ export class LocalStorage extends Storage {
 /**
  * Local storage configuration
  */
-export const createInitializer: StorageInitializerFunction =
+export const createInitializer: StorageInitializerFunction<LocalStorage> =
   (options?: LocalStorageOptions) =>
   // eslint-disable-next-line @typescript-eslint/require-await
   async (): Promise<LocalStorage> => {

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -38,10 +38,16 @@ export class MemoryStorage extends Storage {
 
     // Validate MemoryStorageOptions
 
-    this.db = new Map<string, unknown>(options?.entries);
-
     if (options.scope) {
       this.scopeIdsKey = `memory_storage_scope_${options.scope}_ids`;
+    }
+
+    this.db = new Map<string, unknown>(options?.entries);
+
+    if (options.entries) {
+      options.entries.forEach((e) => {
+        this.addScopeId(e[0]);
+      });
     }
 
     logger.trace('Memory storage initialized');
@@ -86,7 +92,7 @@ export class MemoryStorage extends Storage {
    * @returns
    * @memberof MemoryStorage
    */
-  private addScopeId(id: string) {
+  protected addScopeId(id: string) {
     try {
       if (!this.scopeIdsKey) {
         return;
@@ -220,7 +226,7 @@ export class MemoryStorage extends Storage {
 }
 
 // Storage configuration
-export const createInitializer: StorageInitializerFunction =
+export const createInitializer: StorageInitializerFunction<MemoryStorage> =
   (options?: MemoryStorageOptions) =>
   // eslint-disable-next-line @typescript-eslint/require-await
   async (): Promise<MemoryStorage> => {

--- a/test/storage.memory.spec.ts
+++ b/test/storage.memory.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach } from './setup.js';
+import {
+  MemoryStorage,
+  MemoryStorageOptions,
+  createInitializer,
+} from '../src/storage/memory.js';
+
+describe('MemoryStorage', () => {
+  let memoryStorage: MemoryStorage;
+
+  beforeEach(() => {
+    const options: MemoryStorageOptions = {
+      scope: 'test',
+      entries: [['test', 'value']],
+    };
+    memoryStorage = new MemoryStorage(options);
+  });
+
+  describe('#constructor', () => {
+    it('MemoryStorage is initialized correctly', () => {
+      expect(memoryStorage).toBeDefined();
+      expect(memoryStorage).toBeInstanceOf(MemoryStorage);
+    });
+
+    it('Throws an error when a non-string key is used in the initial entries', () => {
+      const badOptions: MemoryStorageOptions = {
+        entries: {} as Array<[string, unknown]>,
+      };
+      expect(() => new MemoryStorage(badOptions)).toThrow(TypeError);
+    });
+  });
+
+  describe('#set', () => {
+    it('Value is set correctly', async () => {
+      await memoryStorage.set('testKey', 'testValue');
+      const result = await memoryStorage.get('testKey');
+      expect(result).toEqual('testValue');
+    });
+  });
+
+  describe('#get', () => {
+    it('Value is retrieved correctly', async () => {
+      const result = await memoryStorage.get('test');
+      expect(result).toEqual('value');
+    });
+
+    it('Returns undefined when a non-existing key is used', async () => {
+      const result = await memoryStorage.get('nonExistingKey');
+      expect(result).toBeUndefined();
+    });
+
+    it('Throws an error when a non-string key is used', async () => {
+      const result = await memoryStorage.get(undefined as unknown as string);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('#delete', () => {
+    it('Value is deleted correctly', async () => {
+      await memoryStorage.delete('test');
+      const result = await memoryStorage.get('test');
+      expect(result).toBeUndefined();
+    });
+
+    it('Returns false when a non-existing key is used', async () => {
+      const result = await memoryStorage.delete('nonExistingKey');
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('#entries', () => {
+    it('Entries are retrieved correctly', () => {
+      const entries = Array.from(memoryStorage.entries<string>());
+      expect(entries).toContainEqual(['test', 'value']);
+    });
+
+    it('Returns an empty iterator when storage is empty', async () => {
+      await memoryStorage.reset();
+      const entries = Array.from(memoryStorage.entries<string>());
+      expect(entries.length).toEqual(0);
+    });
+  });
+
+  describe('#reset', () => {
+    it('Storage is reset correctly', async () => {
+      await memoryStorage.reset<string>();
+      const result = await memoryStorage.get('test');
+      expect(result).toBeUndefined();
+      const entries = Array.from(memoryStorage.entries<string>());
+      expect(entries.length).toEqual(0);
+    });
+  });
+
+  describe('#createInitializer', () => {
+    it('Initializer creates instance correctly', async () => {
+      const options: MemoryStorageOptions = { scope: 'testInitializer' };
+      const initializer = createInitializer(options);
+      const initializedStorage = await initializer();
+      expect(initializedStorage).toBeInstanceOf(MemoryStorage);
+      expect(initializedStorage.scopeIdsKey).toEqual(
+        'memory_storage_scope_testInitializer_ids',
+      );
+    });
+  });
+});


### PR DESCRIPTION
In this PR:

- Fixed `scope`-ed behaviour of the MEmoryStorage
- Added missed typing of a storage initializer function
- Added tests for the MemoryStorage