### PR TITLE
fix: 🐛 Added missed export of levelDb

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -42,6 +42,16 @@
         "types": "./dist/memory.d.ts",
         "default": "./dist/memory.cjs.js"
       }
+    },
+    "./level": {
+      "import": {
+        "types": "./dist/level.d.ts",
+        "default": "./dist/level.js"
+      },
+      "require": {
+        "types": "./dist/level.d.ts",
+        "default": "./dist/level.cjs.js"
+      }
     }
   },
   "publishConfig": {
@@ -51,7 +61,8 @@
     "@windingtree/sdk-logger": "workspace:*",
     "classic-level": "^1.3.0",
     "level-transcoder": "^1.0.1",
-    "superjson": "^1.13.1"
+    "superjson": "^1.13.1",
+    "buffer": "^6.0.3"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,5 +1,6 @@
 import * as memoryStorage from './memory.js';
 import * as localStorage from './local.js';
+import * as levelStorage from './level.js';
 
 export * from './abstract.js';
-export { memoryStorage, localStorage };
+export { memoryStorage, localStorage, levelStorage };

--- a/packages/storage/src/level.ts
+++ b/packages/storage/src/level.ts
@@ -6,6 +6,7 @@ import {
 import { ClassicLevel } from 'classic-level';
 import { parse, stringify } from 'superjson';
 import { IEncoding } from 'level-transcoder';
+import { Buffer } from 'buffer';
 import { createLogger } from '@windingtree/sdk-logger';
 
 const logger = createLogger('LocalStorage');

--- a/packages/storage/tsup.config.ts
+++ b/packages/storage/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig([
       index: './src/index.ts',
       local: './src/local.ts',
       memory: './src/memory.ts',
+      level: './src/level.ts',
     },
     platform: 'neutral',
     treeshake: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,9 @@ importers:
       '@windingtree/sdk-logger':
         specifier: workspace:*
         version: link:../logger
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       classic-level:
         specifier: ^1.3.0
         version: 1.3.0


### PR DESCRIPTION
In this PR:

- Added missed `levelStorage` export constant to the `@windingtree/sdk-storage` package