### PR TITLE
Fix/cjs export

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-client@1.2.0...@windingtree/sdk-client@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-client
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-client@1.2.0-beta.1...@windingtree/sdk-client@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-client

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The WindingTree market protocol client",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/contracts-manger/package.json
+++ b/packages/contracts-manger/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-db@1.2.0...@windingtree/sdk-db@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-db
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-db@1.2.0-beta.1...@windingtree/sdk-db@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-db

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     },
     "./users": {
@@ -30,7 +30,7 @@
       },
       "require": {
         "types": "./dist/users.d.ts",
-        "default": "./dist/users.cjs.js"
+        "default": "./dist/users.cjs"
       }
     },
     "./deals": {
@@ -40,7 +40,7 @@
       },
       "require": {
         "types": "./dist/deals.d.ts",
-        "default": "./dist/deals.cjs.js"
+        "default": "./dist/deals.cjs"
       }
     }
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-db",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Databases for the WindingTree market protocol",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/node-api/CHANGELOG.md
+++ b/packages/node-api/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-node-api@1.2.0...@windingtree/sdk-node-api@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-node-api
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-node-api@1.2.0-beta.0...@windingtree/sdk-node-api@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-node-api

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-node-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The WindingTree market protocol node API server and client",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     },
     "./router": {
@@ -30,7 +30,7 @@
       },
       "require": {
         "types": "./dist/router.d.ts",
-        "default": "./dist/router.cjs.js"
+        "default": "./dist/router.cjs"
       }
     },
     "./server": {
@@ -40,7 +40,7 @@
       },
       "require": {
         "types": "./dist/server.d.ts",
-        "default": "./dist/server.cjs.js"
+        "default": "./dist/server.cjs"
       }
     },
     "./client": {
@@ -50,7 +50,7 @@
       },
       "require": {
         "types": "./dist/client.d.ts",
-        "default": "./dist/client.cjs.js"
+        "default": "./dist/client.cjs"
       }
     }
   },

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-node@1.2.0...@windingtree/sdk-node@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-node
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-node@1.2.0-beta.0...@windingtree/sdk-node@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-node

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-node",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The WindingTree market protocol node",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/pubsub/CHANGELOG.md
+++ b/packages/pubsub/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-pubsub@1.2.0...@windingtree/sdk-pubsub@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-pubsub
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-pubsub@1.2.0-beta.0...@windingtree/sdk-pubsub@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-pubsub

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-pubsub",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "libp2p PubSub protocol implementation for the WindingTree market protocol",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/queue/CHANGELOG.md
+++ b/packages/queue/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-queue@1.2.0...@windingtree/sdk-queue@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-queue
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-queue@1.2.0-beta.1...@windingtree/sdk-queue@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-queue

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-queue",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Jobs queue",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-react@1.2.0...@windingtree/sdk-react@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-react
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-react@1.2.0-beta.0...@windingtree/sdk-react@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,7 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -19,7 +19,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     },
     "./providers": {
@@ -29,7 +29,7 @@
       },
       "require": {
         "types": "./dist/providers/index.d.ts",
-        "default": "./dist/providers.cjs.js"
+        "default": "./dist/providers.cjs"
       }
     },
     "./utils": {
@@ -39,7 +39,7 @@
       },
       "require": {
         "types": "./dist/utils/index.d.ts",
-        "default": "./dist/utils.cjs.js"
+        "default": "./dist/utils.cjs"
       }
     }
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-server@1.2.0...@windingtree/sdk-server@1.2.1) (2023-10-31)
+
+**Note:** Version bump only for package @windingtree/sdk-server
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-server@1.2.0-beta.0...@windingtree/sdk-server@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The WindingTree market protocol server",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.1](https://github.com/windingtree/sdk/compare/@windingtree/sdk-storage@1.2.0...@windingtree/sdk-storage@1.2.1) (2023-10-31)
+
+
+### Bug Fixes
+
+* 🐛 Added missed export of levelDb ([3887e4e](https://github.com/windingtree/sdk/commit/3887e4ec665e2aafca2c7f2b503cb5a23d4680fe))
+
+
+
+
+
 # [1.2.0](https://github.com/windingtree/sdk/compare/@windingtree/sdk-storage@1.2.0-beta.0...@windingtree/sdk-storage@1.2.0) (2023-10-25)
 
 **Note:** Version bump only for package @windingtree/sdk-storage

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/sdk-storage",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Key-value database abstraction layer",
   "repository": "https://github.com/windingtree/sdk#readme",
   "author": "Kostiantyn Smyrnov <kostysh@gmail.com>",
@@ -59,10 +59,10 @@
   },
   "dependencies": {
     "@windingtree/sdk-logger": "workspace:*",
+    "buffer": "^6.0.3",
     "classic-level": "^1.3.0",
     "level-transcoder": "^1.0.1",
-    "superjson": "^1.13.1",
-    "buffer": "^6.0.3"
+    "superjson": "^1.13.1"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     },
     "./local": {
@@ -30,7 +30,7 @@
       },
       "require": {
         "types": "./dist/local.d.ts",
-        "default": "./dist/local.cjs.js"
+        "default": "./dist/local.cjs"
       }
     },
     "./memory": {
@@ -40,7 +40,7 @@
       },
       "require": {
         "types": "./dist/memory.d.ts",
-        "default": "./dist/memory.cjs.js"
+        "default": "./dist/memory.cjs"
       }
     },
     "./level": {
@@ -50,7 +50,7 @@
       },
       "require": {
         "types": "./dist/level.d.ts",
-        "default": "./dist/level.cjs.js"
+        "default": "./dist/level.cjs"
       }
     }
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     }
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.cjs.js"
+        "default": "./dist/cjs/index.cjs"
       }
     }
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs"
       }
     },
     "./h3": {
@@ -30,7 +30,7 @@
       },
       "require": {
         "types": "./dist/h3.d.ts",
-        "default": "./dist/h3.cjs.js"
+        "default": "./dist/h3.cjs"
       }
     },
     "./regex": {
@@ -40,7 +40,7 @@
       },
       "require": {
         "types": "./dist/regex.d.ts",
-        "default": "./dist/regex.cjs.js"
+        "default": "./dist/regex.cjs"
       }
     },
     "./text": {
@@ -50,7 +50,7 @@
       },
       "require": {
         "types": "./dist/text.d.ts",
-        "default": "./dist/text.cjs.js"
+        "default": "./dist/text.cjs"
       }
     },
     "./time": {
@@ -60,7 +60,7 @@
       },
       "require": {
         "types": "./dist/time.d.ts",
-        "default": "./dist/time.cjs.js"
+        "default": "./dist/time.cjs"
       }
     },
     "./uid": {
@@ -70,7 +70,7 @@
       },
       "require": {
         "types": "./dist/uid.d.ts",
-        "default": "./dist/uid.cjs.js"
+        "default": "./dist/uid.cjs"
       }
     },
     "./wallet": {
@@ -80,7 +80,7 @@
       },
       "require": {
         "types": "./dist/wallet.d.ts",
-        "default": "./dist/wallet.cjs.js"
+        "default": "./dist/wallet.cjs"
       }
     }
   },


### PR DESCRIPTION
This PR adds:

- Fixed file extension for exported common js modules (.cjs)