### PR TITLE
Fixed node-api types declarations

### DIFF
--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -25,11 +25,11 @@
     },
     "./router": {
       "import": {
-        "types": "./dist/router.d.ts",
+        "types": "./dist/router/index.d.ts",
         "default": "./dist/router.js"
       },
       "require": {
-        "types": "./dist/router.d.ts",
+        "types": "./dist/router/index.d.ts",
         "default": "./dist/router.cjs"
       }
     },
@@ -79,7 +79,7 @@
     "zod": "^3.22.4"
   },
   "scripts": {
-    "build": "rm -rf dist && tsup",
+    "build": "rm -rf dist && tsc -p ./tsconfig-build.json --emitDeclarationOnly  && tsup",
     "lint": "eslint . --ext .ts --ignore-path ../../.lintignore",
     "lint:fix": "eslint . --ext .ts --ignore-path ../../.lintignore --fix && prettier --ignore-path ../../.lintignore  --write .",
     "test": "vitest --run test",

--- a/packages/node-api/src/server.ts
+++ b/packages/node-api/src/server.ts
@@ -328,10 +328,12 @@ export class NodeApiServer {
         .split(';')
         .reduce<Record<string, string>>((a, v) => {
           const pair = v.split('=');
-          return {
-            ...a,
-            [pair[0].toLowerCase()]: pair[1],
-          };
+          if (pair.length === 2) {
+            Object.assign(a, {
+              [pair[0].toLowerCase().trim()]: pair[1].trim(),
+            });
+          }
+          return a;
         }, {});
       accessToken = cookies[ACCESS_TOKEN_NAME.toLocaleLowerCase()];
     }

--- a/packages/node-api/tsup.config.ts
+++ b/packages/node-api/tsup.config.ts
@@ -24,7 +24,7 @@ export default defineConfig([
     },
     platform: 'node',
     treeshake: true,
-    dts: { resolve: true },
+    // dts: { resolve: true },
     sourcemap: true,
     format: ['esm', 'cjs'],
     external: Object.keys(dependencies),


### PR DESCRIPTION
Now types for this package are built with `tsc` instead of `plugin-rollup-dts` of `tsup` builder