### PR TITLE
Fix broken link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ pnpm example:client
 
 ## Contributing
 
-[Contribution guidelines](https://windingtree.github.io/sdk/#/docs/contribution)
+[Contribution guidelines](https://windingtree.github.io/sdk/#/contribution)


### PR DESCRIPTION
The link is broken. My proposed change fixes the link.

- old broken link: https://windingtree.github.io/sdk/#/docs/contribution
- proper link: https://windingtree.github.io/sdk/#/contribution